### PR TITLE
Add event persistence

### DIFF
--- a/Source/EventFlow.MongoDB/EventFlow.MongoDB.csproj
+++ b/Source/EventFlow.MongoDB/EventFlow.MongoDB.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
     <PackageId>EventFlow.MongoDB</PackageId>
-    <PackageVersion>0.0.2</PackageVersion>
+    <PackageVersion>0.0.6</PackageVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/Source/EventFlow.MongoDB/EventFlow.MongoDB.csproj
+++ b/Source/EventFlow.MongoDB/EventFlow.MongoDB.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
     <PackageId>EventFlow.MongoDB</PackageId>
-    <PackageVersion>0.0.6</PackageVersion>
+    <PackageVersion>0.0.3</PackageVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/Source/EventFlow.MongoDB/EventStore/IMongoDbEventSequenceStore.cs
+++ b/Source/EventFlow.MongoDB/EventStore/IMongoDbEventSequenceStore.cs
@@ -1,0 +1,7 @@
+﻿namespace EventFlow.MongoDB.EventStore
+{
+    public interface IMongoDbEventSequenceStore
+    {
+        long GetNextSequence(string name);
+    }
+}

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistence.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistence.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Aggregates;
+using EventFlow.Core;
+using EventFlow.EventStores;
+using EventFlow.Logs;
+using EventFlow.MongoDB.ValueObjects;
+using MongoDB.Driver;
+
+namespace EventFlow.MongoDB.EventStore
+{
+    public class MongoDbEventPersistence : IEventPersistence
+    {
+        private const string _collectionName = "eventflow.events";
+        private readonly ILog _log;
+        private readonly IMongoDatabase _mongoDatabase;
+        private readonly IMongoDbEventSequenceStore _mongoDbEventSequenceStore;
+
+        public MongoDbEventPersistence(ILog log, IMongoDatabase mongoDatabase, IMongoDbEventSequenceStore mongoDbEventSequenceStore)
+        {
+            _log = log;
+            _mongoDatabase = mongoDatabase;
+            _mongoDbEventSequenceStore = mongoDbEventSequenceStore;
+        }
+
+        public async Task<AllCommittedEventsPage> LoadAllCommittedEvents(GlobalPosition globalPosition, int pageSize, CancellationToken cancellationToken)
+        {
+            long startPosition = globalPosition.IsStart
+                ? 0
+                : long.Parse(globalPosition.Value);
+            long endPosition = startPosition + pageSize;
+
+            List<MongoDbEventDataModel> eventDataModels = await MongoDbEventStoreCollection
+                .Find(model => model._id >= startPosition && model._id <= endPosition)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(continueOnCapturedContext: false);
+            
+            long nextPosition = eventDataModels.Any()
+                ? eventDataModels.Max(e => e._id) + 1
+                : startPosition;
+
+            return new AllCommittedEventsPage(new GlobalPosition(nextPosition.ToString()), eventDataModels);
+        }
+
+        public async Task<IReadOnlyCollection<ICommittedDomainEvent>> CommitEventsAsync(IIdentity id, IReadOnlyCollection<SerializedEvent> serializedEvents, CancellationToken cancellationToken)
+        {
+            if (!serializedEvents.Any())
+            {
+                return new ICommittedDomainEvent[] { };
+            }
+
+            var eventDataModels = serializedEvents
+                .Select((e, i) => new MongoDbEventDataModel
+                {
+                    _id = _mongoDbEventSequenceStore.GetNextSequence(_collectionName),
+                    AggregateId = id.Value,
+                    AggregateName = e.Metadata[MetadataKeys.AggregateName],
+                    BatchId = Guid.Parse(e.Metadata[MetadataKeys.BatchId]),
+                    Data = e.SerializedData,
+                    Metadata = e.SerializedMetadata,
+                    AggregateSequenceNumber = e.AggregateSequenceNumber
+                })
+                .OrderBy(x => x.AggregateSequenceNumber)
+                .ToList();
+
+            _log.Verbose("Committing {0} events to MongoDb event store for entity with ID '{1}'", eventDataModels.Count, id);
+            await MongoDbEventStoreCollection
+                .InsertManyAsync(eventDataModels, cancellationToken: cancellationToken)
+                .ConfigureAwait(continueOnCapturedContext: false);
+
+            return eventDataModels;
+        }
+
+        public async Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadCommittedEventsAsync(IIdentity id, int fromEventSequenceNumber, CancellationToken cancellationToken)
+        {
+            return await MongoDbEventStoreCollection
+                .Find(model => model.AggregateId == id.Value && model.AggregateSequenceNumber >= fromEventSequenceNumber)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(continueOnCapturedContext: false);
+        }
+
+        public async Task DeleteEventsAsync(IIdentity id, CancellationToken cancellationToken)
+        {
+            DeleteResult affectedRows = await MongoDbEventStoreCollection
+                .DeleteManyAsync(x => x.AggregateId == id.Value, cancellationToken)
+                .ConfigureAwait(continueOnCapturedContext: false);
+
+            _log.Verbose("Deleted entity with ID '{0}' by deleting all of its {1} events", id, affectedRows.DeletedCount);
+        }
+
+        private IMongoCollection<MongoDbEventDataModel> MongoDbEventStoreCollection => _mongoDatabase.GetCollection<MongoDbEventDataModel>(_collectionName);
+    }
+}

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventSeqanceStore.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventSeqanceStore.cs
@@ -1,0 +1,29 @@
+﻿using EventFlow.MongoDB.ValueObjects;
+using MongoDB.Driver;
+
+namespace EventFlow.MongoDB.EventStore
+{
+    using System.Threading;
+
+    public class MongoDbEventSequenceStore : IMongoDbEventSequenceStore
+    {
+        private const string _collectionName = "eventflow.counter";
+        private readonly IMongoDatabase _mongoDatabase;
+
+        public MongoDbEventSequenceStore(IMongoDatabase mongoDatabase)
+        {
+            _mongoDatabase = mongoDatabase;
+        }
+
+        public long GetNextSequence(string name)
+        {
+            MongoDbCounterDataModel ret = _mongoDatabase.GetCollection<MongoDbCounterDataModel>(_collectionName)
+                .FindOneAndUpdate<MongoDbCounterDataModel>(
+                    x => x._id == name,
+                    new UpdateDefinitionBuilder<MongoDbCounterDataModel>().Inc(x => x.Seq, value: 1),
+                    new FindOneAndUpdateOptions<MongoDbCounterDataModel> {IsUpsert = true});
+
+            return ret.Seq;
+        }
+    }
+}

--- a/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsMongoDbEventStoreExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsMongoDbEventStoreExtensions.cs
@@ -1,0 +1,13 @@
+﻿using EventFlow.Extensions;
+using EventFlow.MongoDB.EventStore;
+
+namespace EventFlow.MongoDB.Extensions
+{
+    public static class EventFlowOptionsMongoDbEventStoreExtensions
+    {
+        public static IEventFlowOptions UseMongoDbEventStore(this IEventFlowOptions eventFlowOptions)
+        {
+            return eventFlowOptions.UseEventStore<MongoDbEventPersistence>();
+        }
+    }
+}

--- a/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
@@ -2,6 +2,7 @@
 using EventFlow.Extensions;
 using EventFlow.MongoDB.ReadStores;
 using EventFlow.ReadStores;
+using EventFlow.MongoDB.EventStore;
 using MongoDB.Driver;
 using System;
 
@@ -47,6 +48,7 @@ namespace EventFlow.MongoDB.Extensions
                 sr.Register(f => mongoDatabaseFactory(), Lifetime.Singleton);
                 sr.Register<IReadModelDescriptionProvider, ReadModelDescriptionProvider>(Lifetime.Singleton, true);
                 sr.Register<IInsertOnlyReadModelDescriptionProvider, InsertOnlyReadModelDescriptionProvider>(Lifetime.Singleton, true);
+                sr.Register<IMongoDbEventSequenceStore, MongoDbEventSequenceStore>(Lifetime.Singleton);
             });
         }
 

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbCounterDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbCounterDataModel.cs
@@ -1,0 +1,13 @@
+﻿using EventFlow.ValueObjects;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace EventFlow.MongoDB.ValueObjects
+{
+    public class MongoDbCounterDataModel : ValueObject
+    {
+        public string _id { get; set; }
+
+        [BsonElement("seq")]
+        public int Seq { get; set; }
+    }
+}

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbEventDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbEventDataModel.cs
@@ -1,26 +1,33 @@
-﻿using EventFlow.ValueObjects;
-using MongoDB.Bson;
+﻿using System;
+using EventFlow.EventStores;
+using EventFlow.ValueObjects;
 using MongoDB.Bson.Serialization.Attributes;
 using Newtonsoft.Json;
 
 namespace EventFlow.MongoDB.ValueObjects
 {
-    using System;
-    using EventStores;
-
-    public class MongoDbSnapshotDataModel : ValueObject
+    public class MongoDbEventDataModel : ValueObject, ICommittedDomainEvent
     {
         [BsonElement("_id")]
-        public ObjectId _id { get; set; }
+        public long _id { get; set; }
+
+        [JsonProperty("batchId")]
+        public Guid BatchId { get; set; }
+
         long? _version { get; set; }
+
         [JsonProperty("aggregateId")]
         public string AggregateId { get; set; }
+
         [JsonProperty("aggregateName")]
         public string AggregateName { get; set; }
+
         [JsonProperty("aggregateSequenceNumber")]
         public int AggregateSequenceNumber { get; set; }
+
         [JsonProperty("data")]
         public string Data { get; set; }
+
         [JsonProperty("metaData")]
         public string Metadata { get; set; }
     }

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbSnapshotDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbSnapshotDataModel.cs
@@ -5,9 +5,6 @@ using Newtonsoft.Json;
 
 namespace EventFlow.MongoDB.ValueObjects
 {
-    using System;
-    using EventStores;
-
     public class MongoDbSnapshotDataModel : ValueObject
     {
         [BsonElement("_id")]


### PR DESCRIPTION
Implemented IEventPersistence for MongoDb. 

_This uses a global incrementing id for the event collection. Due to the nature of MongoDb not being designed this way long term performance in a highly concurrent environment might need to be considered._
 