### PR TITLE
Making injected dependencies public readable so they can be accessed in custom extension methods

### DIFF
--- a/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
@@ -3,6 +3,7 @@ using System;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using EventFlow.Logs;
 using MongoDB.Driver;
 
 namespace EventFlow.MongoDB.ReadStores
@@ -10,6 +11,10 @@ namespace EventFlow.MongoDB.ReadStores
 	public interface IMongoDbReadModelStore<TReadModel> : IReadModelStore<TReadModel>
 		where TReadModel : class, IReadModel, new()
 	{
+		ILog Log { get; }
+		IMongoDatabase MongoDatabase { get; }
+		IReadModelDescriptionProvider ReadModelDescriptionProvider { get; }
+
 		Task<IAsyncCursor<TReadModel>> FindAsync(
 			Expression<Func<TReadModel, bool>> filter,
 			FindOptions<TReadModel, TReadModel> options = null,


### PR DESCRIPTION
Possible extensions methods could be:

- Counting data via CountAsync
- Querying via AsQueryable returning a IMongoQueryable
- FindAsync with FilterDefinitionBuilder as parameter